### PR TITLE
fix: Patch an issue with schedule counter

### DIFF
--- a/script.js
+++ b/script.js
@@ -330,7 +330,7 @@ function checkTime() {
   const diff = Math.floor((now.getTime() - stationTime.getTime()) / 1000);
   let minutes = Math.round(Math.abs(diff) / 60);
   const seconds = Math.abs(diff % 60);
-  if(seconds > 30)
+  if(seconds >= 30)
     minutes = minutes - 1;
   const time = `Next Stop: ${active[0].children[1].innerText} | <span id="lateness">${setPrefix(diff, minutes, seconds)}${("00"+minutes).slice(-2)}:${("00"+seconds).slice(-2)}</span>`;
   text.innerHTML = time;


### PR DESCRIPTION
At exactly 30 seconds, the time is one minute higher than it should be. This is because the condition for the minute subtraction is anything above 30 seconds, excluding 30 seconds.